### PR TITLE
Implement QldbHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,4 +3,93 @@
 [[package]]
 name = "amazon-qldb-driver-rust"
 version = "0.1.0"
+dependencies = [
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+"checksum bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+"checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+"checksum generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+"checksum hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+"checksum opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+"checksum sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+"checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "0.5.6"
+sha2 = "0.9.1"
+
+[dev-dependencies]
+hex-literal = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod qldb_hash;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/qldb_hash.rs
+++ b/src/qldb_hash.rs
@@ -1,0 +1,144 @@
+use bytes::{Bytes, BytesMut};
+use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
+
+const HASH_SIZE: usize = 32;
+
+/// A [`QldbHash`] is either a 256 bit number or a special empty hash.
+#[derive(PartialEq, Clone, Debug)]
+pub struct QldbHash {
+    bytes: Bytes,
+}
+
+impl QldbHash {
+    pub fn from_bytes(bytes: Bytes) -> Option<QldbHash> {
+        match bytes.len() {
+            0 | HASH_SIZE => Some(QldbHash { bytes }),
+            _ => None,
+        }
+    }
+
+    pub fn dot(&self, other: &QldbHash) -> QldbHash {
+        dot(self, other)
+    }
+
+    pub fn bytes(&self) -> Bytes {
+        self.bytes.clone()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+impl PartialOrd for QldbHash {
+    /// Goes through the byte arrays from the last byte to the first. The
+    /// first bytes that aren't equal determine ordering.
+    ///
+    /// Note: The byte arrays are always either 0 or `HASH_SIZE`, see
+    /// the constructor.
+    fn partial_cmp(&self, other: &QldbHash) -> Option<Ordering> {
+        if self.is_empty() {
+            if other.is_empty() {
+                return Some(Ordering::Equal);
+            } else {
+                return Some(Ordering::Less);
+            }
+        }
+
+        if other.is_empty() {
+            return Some(Ordering::Greater);
+        }
+
+        for (x, y) in self.bytes.iter().rev().zip(other.bytes.iter().rev()) {
+            // Note that Java compares bytes as signed integers. We
+            // store the bytes as unsigned bytes everywhere and simply
+            // re-interpret the bits at this point to determine
+            // ordering.
+            match (*x as i8).cmp(&(*y as i8)) {
+                Ordering::Equal => {}
+                cmp => return Some(cmp),
+            }
+        }
+
+        return Some(Ordering::Equal);
+    }
+}
+
+impl Default for QldbHash {
+    fn default() -> QldbHash {
+        QldbHash::from_bytes(Bytes::default()).unwrap()
+    }
+}
+
+pub fn dot(x: &QldbHash, y: &QldbHash) -> QldbHash {
+    if x.is_empty() {
+        return y.clone();
+    }
+    if y.is_empty() {
+        return x.clone();
+    }
+
+    let mut bytes = BytesMut::with_capacity(x.bytes.len() + y.bytes.len());
+
+    if x < y {
+        bytes.extend(&x.bytes);
+        bytes.extend(&y.bytes);
+    } else {
+        bytes.extend(&y.bytes);
+        bytes.extend(&x.bytes);
+    }
+
+    // NOTE: The produced bytes will always be of len() = HASH_SIZE,
+    // because that's what Sha256 produces.
+    let digest = sha256(&bytes.freeze());
+    QldbHash::from_bytes(digest).unwrap()
+}
+
+fn sha256(bytes: &Bytes) -> Bytes {
+    let digest = Sha256::digest(&bytes);
+    BytesMut::from(digest.as_slice()).freeze()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+    use hex_literal::hex;
+
+    #[test]
+    fn dot_examples() {
+        // QldbHash wants 0 or 256 len byte arrays. That's tedious to type. This macro takes a literal string and uses sha256 to produce a 256-len value. In this way we can test
+        // properties without verbose examples.
+        macro_rules! s {
+            ($value:expr) => {
+                &QldbHash::from_bytes(sha256(&BytesMut::from($value.as_bytes()).freeze())).unwrap()
+            };
+        }
+
+        // QldbHash commutes
+        assert_eq!(dot(s!("1"), s!("2")), dot(s!("2"), s!("1")));
+
+        // Empty hashes
+        assert_eq!(
+            dot(&QldbHash::default(), &QldbHash::default()),
+            QldbHash::default()
+        );
+        assert_eq!(dot(s!("1"), &QldbHash::default()), *s!("1"));
+        assert_eq!(dot(&QldbHash::default(), s!("1")), *s!("1"));
+
+        // An actual example, values checked against the Java implementation
+        assert_eq!(
+            s!("1").bytes[..],
+            hex!("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")[..]
+        );
+        assert_eq!(
+            s!("2").bytes[..],
+            hex!("d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35")[..]
+        );
+        assert_eq!(
+            dot(s!("1"), s!("2")).bytes[..],
+            hex!("940ed9abddfb5ef28004408546bc5043cda391232b6afe07267f9f8ed2b500c9")[..]
+        );
+    }
+}


### PR DESCRIPTION
This commit implements QldbHash according to the
specification. QldbHashes are used by the driver to produce a "commit
digest", without which commits cannot be made. They're essentially
just wrappers over SHA256 with a 'dot' operator that can be used to
combine two hashes into one.

The most tricky part is the ordering of hashes, which is well
documented in the implementation.

This commit includes tests that exercise the dot function against
various input permutations.

The Java implementation has constructors that produce QldbHashes from
either an IonValue or String. We will implement these in future
commits, as we pull in our Ion dependencies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
