### PR TITLE
Add the driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,11 +9,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "amazon-qldb-driver-rust"
+name = "amazon-qldb-driver"
 version = "0.1.0"
 dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ion-c-sys 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,6 +30,14 @@ dependencies = [
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1635,6 +1645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "amazon-qldb-driver-rust"
+name = "amazon-qldb-driver"
 version = "0.1.0"
 authors = ["Amazon QLDB Team https://aws.amazon.com/qldb"]
 edition = "2018"
@@ -7,16 +7,18 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.41"
+thiserror = "1.0.21"
+tokio = "0.2.22"
 bytes = "0.5.6"
-ion-c-sys = "0.4.3"
-log = "0.4.11"
+async-trait = "0.1.41"
 rusoto_core = "0.45.0"
 rusoto_qldb_session = "0.45.0"
 sha2 = "0.9.1"
-thiserror = "1.0.21"
-tokio = "0.2.22"
+log = "0.4.11"
+ion-c-sys = "0.4.3"
 rand = "0.7.3"
 
 [dev-dependencies]
 hex-literal = "0.3.1"
+env_logger = "0.7.1"
+ansi_term = "0.12.1"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,41 @@
+use amazon_qldb_driver::ion_compat;
+use amazon_qldb_driver::QldbDriver;
+use rusoto_core::Region;
+use tokio;
+#[macro_use]
+extern crate log;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    info!("Creating a QLDB driver");
+    let driver = QldbDriver::builder()
+        .ledger_name("sample-ledger")
+        .region(Region::UsWest2)
+        .build()?;
+
+    // Usage example 1: Here we use a closure that returns a `Result<R, QldbError>`. The closure is wrapped in ceremony to appease the type system.
+    info!("Transaction example 1 now running");
+    let results = driver
+        .transact(|mut tx| async {
+            let results = tx
+                .execute_statement("select value 42 from information_schema.user_tables")
+                .await?;
+
+            tx.ok(results).await
+        })
+        .await?;
+    info!("Tx 1 returned {} result(s):", results.len());
+    for reader in results.readers() {
+        let pretty = ion_compat::to_string_pretty(reader?)?;
+        info!("{}", pretty);
+    }
+
+    // No support for Ion yet!
+    // assert_eq!(42, value);
+
+    info!("Goodbye!");
+
+    Ok(())
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,378 @@
+use crate::api::QldbSessionApi;
+use crate::rusoto_ext::*;
+use crate::transaction::{Transaction, TransactionAttempt, TransactionDisposition};
+use crate::{
+    pool::SessionPool, retry::default_retry_policy, retry::TransactionRetryPolicy, QldbError,
+};
+use runtime::Runtime;
+use rusoto_core::{
+    credential::{DefaultCredentialsProvider, ProvideAwsCredentials},
+    Client, HttpClient, Region, RusotoError,
+};
+use rusoto_qldb_session::*;
+use std::error::Error as StdError;
+use std::{cell::RefCell, future::Future};
+use tokio::{runtime, sync::mpsc::channel};
+
+/// A builder to help you customize a [`QldbDriver`].
+///
+/// In many cases, it is sufficient to use [`QldbDriver::new`] to build a driver out of a Rusoto client for a particular QLDB ledger. However, if you wish to customize the driver beyond the
+/// defaults, this builder is what you want.
+///
+/// Note that the following setters _must_ be called, else [`build`] will return an `Err`:
+/// - `ledger_name`
+/// - `client`
+///
+/// Usage example:
+/// ```no_run
+/// # use amazon_qldb_driver::QldbDriverBuilder;
+/// # use rusoto_core::region::Region;
+/// # use rusoto_qldb_session::QldbSessionClient;
+/// #
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = QldbSessionClient::new(Region::UsWest2);
+/// let driver = QldbDriverBuilder::new()
+///     .ledger_name("sample-ledger")
+///     .region(Region::UsEast1)
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct QldbDriverBuilder {
+    ledger_name: Option<String>,
+    credentials_provider: BoxedCredentialsProvider,
+    region: Option<Region>,
+    transaction_retry_policy: Box<dyn TransactionRetryPolicy>,
+    max_sessions: usize,
+}
+
+impl Default for QldbDriverBuilder {
+    fn default() -> Self {
+        QldbDriverBuilder {
+            ledger_name: None,
+            credentials_provider: into_boxed(
+                DefaultCredentialsProvider::new().expect("failed to create credentials provider"),
+            ),
+            region: None,
+            transaction_retry_policy: Box::new(default_retry_policy()),
+            max_sessions: 1500,
+        }
+    }
+}
+
+impl QldbDriverBuilder {
+    pub fn new() -> Self {
+        QldbDriverBuilder::default()
+    }
+
+    pub fn ledger_name<S>(mut self, ledger_name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.ledger_name = Some(ledger_name.into());
+        self
+    }
+
+    pub fn credentials_provider<P>(mut self, credentials_provider: P) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+    {
+        self.credentials_provider = into_boxed(credentials_provider);
+        self
+    }
+
+    pub fn region(mut self, region: Region) -> Self {
+        self.region = Some(region);
+        self
+    }
+
+    pub fn transaction_retry_policy<P>(mut self, transaction_retry_policy: P) -> Self
+    where
+        P: TransactionRetryPolicy + Send + Sync + 'static,
+    {
+        self.transaction_retry_policy = Box::new(transaction_retry_policy);
+        self
+    }
+
+    pub fn max_sessions(mut self, max_sessions: usize) -> Self {
+        self.max_sessions = max_sessions;
+        self
+    }
+
+    pub fn build(self) -> Result<QldbDriver, Box<dyn StdError>> {
+        let ledger_name = self.ledger_name.ok_or("ledger_name must be initialized")?;
+        let client = Client::new_with(self.credentials_provider, default_dispatcher()?);
+        let region = self.region.unwrap_or(Region::default());
+        let qldb_client = QldbSessionClient::new_with_client(client, region);
+
+        Ok(QldbDriver {
+            ledger_name: ledger_name.clone(),
+            client: qldb_client.clone(),
+            session_pool: SessionPool::new(
+                qldb_client.clone(),
+                ledger_name.clone(),
+                self.max_sessions,
+            ),
+            transaction_retry_policy: self.transaction_retry_policy,
+        })
+    }
+}
+
+fn default_dispatcher() -> Result<HttpClient, Box<dyn StdError>> {
+    let mut client = HttpClient::new()?;
+    client.local_agent(format!(
+        "QLDB Driver for Rust v{}",
+        env!("CARGO_PKG_VERSION")
+    ));
+    Ok(client)
+}
+
+// FIXME: Make trait, make Clone/Sync?
+pub struct QldbDriver {
+    ledger_name: String,
+    client: QldbSessionClient,
+    session_pool: SessionPool,
+    transaction_retry_policy: Box<dyn TransactionRetryPolicy>,
+}
+
+impl QldbDriver {
+    /// Discovery shortcut: use the builder!
+    pub fn builder() -> QldbDriverBuilder {
+        QldbDriverBuilder::new()
+    }
+
+    pub fn ledger_name(&self) -> String {
+        self.ledger_name.clone()
+    }
+
+    /// Execute a transaction against QLDB, retrying as necessary.
+    ///
+    /// This function is the primary way you should interact with QLDB. The driver will acquire a connection and open a [`Transaction`], handing it to your code (the closure you pass
+    /// in). The driver will run your transaction and attempt to commit it. While executing the transaction, failures may occur. The driver will retry (acquire a new transaction and run your
+    /// code again). This means your code *must be idempotent*.
+    ///
+    /// If you wish to get results out of your transaction, you must return them from your closure. Do not attempt to write to variables outside of your closure! You should consider code
+    /// running inside the closure as seeing speculative results that are only confirmed once the transaction commits.
+    ///
+    /// Here is some example code:
+    ///
+    /// ```no_run
+    /// use tokio;
+    /// use amazon_qldb_driver::QldbDriver;
+    /// use rusoto_core::region::Region;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let driver = QldbDriver::builder().ledger_name("sample-ledger").build()?;
+    ///     let (a, b) = driver.transact(|mut tx| async {
+    ///         let a = tx.execute_statement("SELECT 1").await?;
+    ///         let b = tx.execute_statement("SELECT 2").await?;
+    ///         tx.ok((a, b)).await
+    ///     }).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Note that the `transaction` argument is `Fn` not `FnOnce` or `FnMut`. This is to support retries (of the entire transaction) and ensure that your function is idempotent (cannot
+    /// mutate the environment it captures). For example the following will not compile:
+    ///
+    /// ```compile_fail
+    /// # use tokio;
+    /// # use amazon_qldb_driver::QldbDriver;
+    /// # use rusoto_core::region::Region;
+    /// # 
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// #   let driver = QldbDriver::builder().ledger_name("sample-ledger").build()?;
+    ///     let mut string = String::new();
+    ///     driver.transact(|tx| async {
+    ///        string.push('1');
+    ///        tx.ok(()).await
+    ///     }).await?;
+    /// # 
+    /// #   Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Again, this is because `transaction` is `Fn` not `FnMut` and thus is not allowed to mutate `string`.
+    pub async fn transact<F, Fut, R>(&self, transaction: F) -> Result<R, Box<dyn StdError>>
+    where
+        Fut: Future<Output = Result<TransactionAttempt<R>, Box<dyn StdError>>>,
+        F: Fn(Transaction) -> Fut,
+    {
+        let mut attempt_number = 0u32;
+
+        loop {
+            attempt_number += 1;
+
+            let session_handle = self.session_pool.next().await?;
+            let session_token = &session_handle.session_token;
+
+            let tx_id = self.client.start_transaction(&session_token).await?;
+            let (sender, mut receiver) = channel(1);
+            let tx = Transaction::new(
+                Box::new(self.client.clone()),
+                session_token.clone(),
+                tx_id.clone(),
+                sender,
+            );
+
+            // Run the user's transaction. They can run methods on [`Transaction`] such as [`execute_statement`]. When this future completes, one of 4 things could have happened:
+            //
+            // 1. The user code ended with `tx.ok(R)`. This means we get instructions back to attempt a commit. If the commit succeeds, the user gets their data.
+            // 2. The user code ended with `tx.abort(R)`. Similar story, but we attempt to abort. Even if the abort fails, the user gets their data back.
+            // 3. The user code returned an `Err`:
+            //    a. If it is a QldbError that is retriable (e.g. consider a communications failure), then the transaction is retried.
+            //    b. Otherwise, we return the error to the user.
+            let result = match transaction(tx).await {
+                Ok(a) => {
+                    // This should never happen, but because we move the Transaction into the closure, we need to assert the user returns a `TransactionAttempt` for that same transaction!
+                    if a.tx_id != tx_id {
+                        return Err(QldbError::UsageError(format!("the call to transact passed your code a Transaction with id {} but you returned instructions for Transaction with id {}", tx_id, a.tx_id)))?;
+                    }
+
+                    match a.disposition {
+                        TransactionDisposition::Abort => {
+                            debug!("transaction {} will be aborted", a.tx_id);
+
+                            // If a user calls abort and the API request fails, simply ignore the failure. There are a couple of reasons for this choice.
+                            //
+                            // First off, failure is inevitable. There may be communication failure (e.g. WiFi is spotty), API failure (e.g. request throttling) or usage failure
+                            // (e.g. session or transaction has timed out). It may be that the transaction is already aborted, or eventually will be due to server-side timeouts.
+                            //
+                            // Next, safety. It is possible that a failure to abort the transaction here may lead to a problem with the next transaction. For example, consider a network
+                            // error such that the server doesn't receive the abort (transaction is still open server-side). When the session is re-used, the next StartTransaction request
+                            // might fail ("transaction already open"). This is not a safety issue, but it will cause user-level failures as BadRequests are typically not retried.
+                            //
+                            // So, we take the pragmatic approach and mark the session as invalid. This prevents it being returned to the pool.
+                            if let Err(e) = self.client.abort_transaction(session_token).await {
+                                debug!("ignoring failure to abort tx {}: {}", a.tx_id, e);
+                                session_handle.notify_invalid();
+                            }
+
+                            // If a user calls abort, they will get `Ok(user_data)` returned. This does not allow a disambiguation between data that was committed (verified by OCC) versus
+                            // data that was captured in an aborted transaction. Consider an alternative API where the Result Ok variant is an Enum with either `Committed(data)` or
+                            // `Uncommitted(data)`. More clear, but also much more annoying to work with. Because this API is generic over `R`, we leave the commit/abort wrapping up to
+                            // users.
+                            return Ok(a.user_data);
+                        }
+                        TransactionDisposition::Commit => {
+                            debug!("transaction {} will be committed", a.tx_id);
+                            Ok(a.user_data)
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!("transaction {} failed with error: {}", tx_id, e);
+
+                    match e.downcast::<QldbError>() {
+                        Ok(qldb_err) => {
+                            // This error will flow through the next match statement to the error handling block at the bottom. It would be cleaner to extract and call and error handler
+                            // here, but that function lands up capturing so many variables it's not worth it.
+                            Err(*qldb_err)
+                        }
+                        // This branch means the transaction block failed with a non-QldbError. This means something unrelated to QLDB went wrong.
+                        Err(other) => {
+                            return Err(other);
+                        }
+                    }
+                }
+            };
+
+            // There are two possibilities at this point in the code. Either the block of code `transaction` ended with [`Transaction.ok`] or a [`QldbError`] was encountered. The other cases
+            // are already handled:
+            //
+            // 1. [`Transaction.abort`] will have returned the data
+            // 2. Another disposition will be compile-fail
+            // 3. Another error will return the `Err` to the user
+            //
+            // So all that's left to do is commit (for the `ok` case) and then go into error handling (for the QldbError case OR if the commit fails).
+            let attempt = match result {
+                Ok(user_data) => {
+                    // TODO: Assert the digest is for this transaction. Maybe that the channel is closed and also send the tx id with the digest?
+                    match receiver.recv().await {
+                        Some(commit_digest) => self
+                            .client
+                            .commit_transaction(session_token, tx_id.clone(), commit_digest.bytes())
+                            .await
+                            .and_then(|_| Ok(user_data)),
+                        None => {
+                            return Err(QldbError::IllegalState(format!("Attempting to commit transaction {} but the channel holding the commit digest was closed", tx_id)))?;
+                        }
+                    }
+                }
+                _ => result,
+            };
+
+            // At this point, `attempt` is either `Ok(R)` (in which case we return it to the user - this is a successful commit), or it is an error. The error may have come before or after
+            // the attempt to commit. Either way, we need to figure out if the session should be marked invalid and/or if we should retry from the top.
+            match attempt {
+                Ok(user_data) => return Ok(user_data),
+                Err(e) => {
+                    // Note: This catch block is after the attempt to commit. We also have to call `notify_valid` before this attempt for the case where one of the commands send during
+                    // execution of the user code ran into the ISE. Also note that we should not even attempt to commit if the previous error was an ISE! Currently this is taken care of by
+                    // not retrying at all (when user code fails; we only retry on OCC during commit).
+                    if let QldbError::Rusoto(RusotoError::Service(
+                        SendCommandError::InvalidSession(_),
+                    )) = e
+                    {
+                        session_handle.notify_invalid();
+                    }
+
+                    let should_retry = self
+                        .transaction_retry_policy
+                        .on_err(&e, attempt_number)
+                        .await;
+                    if should_retry {
+                        debug!(
+                            "Error comitting ({}) on attempt {}, will retry",
+                            e, attempt_number
+                        );
+                    } else {
+                        debug!(
+                            "Not retrying after {} attempts due to error: {}",
+                            attempt_number, e
+                        );
+
+                        return Err(e)?;
+                    }
+                }
+            }
+
+            // Here we retry. We're in a loop, remember!
+        }
+    }
+
+    pub fn into_blocking(self) -> Result<BlockingQldbDriver, Box<dyn std::error::Error>> {
+        BlockingQldbDriver::new(self)
+    }
+}
+
+pub struct BlockingQldbDriver {
+    async_driver: QldbDriver,
+    runtime: RefCell<Runtime>,
+}
+
+impl BlockingQldbDriver {
+    fn new(async_driver: QldbDriver) -> Result<BlockingQldbDriver, Box<dyn std::error::Error>> {
+        let runtime = runtime::Builder::new()
+            .basic_scheduler()
+            .enable_all()
+            .build()?;
+        Ok(BlockingQldbDriver {
+            async_driver: async_driver,
+            runtime: RefCell::new(runtime),
+        })
+    }
+
+    pub fn transact<F, Fut, R>(&self, transaction: F) -> Result<R, Box<dyn StdError>>
+    where
+        Fut: Future<Output = Result<TransactionAttempt<R>, Box<dyn StdError>>>,
+        F: Fn(Transaction) -> Fut,
+    {
+        let mut runtime = self.runtime.borrow_mut();
+        let fun = &transaction;
+        runtime.block_on(async move { self.async_driver.transact(fun).await })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,15 @@ use thiserror::Error;
 extern crate log;
 
 pub mod api;
+pub mod driver;
 pub mod ion_compat;
 pub mod pool;
 pub mod qldb_hash;
 pub mod retry;
+pub mod rusoto_ext;
+pub mod transaction;
+
+pub use crate::driver::{BlockingQldbDriver, QldbDriver, QldbDriverBuilder};
 
 #[derive(Error, Debug)]
 pub enum QldbError {

--- a/src/rusoto_ext.rs
+++ b/src/rusoto_ext.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+use rusoto_core::credential::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
+
+/// Rusoto generates client constructors that look like this:
+///
+/// ```skip
+///  pub fn new_with<P, D>(
+///      request_dispatcher: D,
+///      credentials_provider: P,
+///      region: region::Region,
+///  ) -> QldbSessionClient
+///  where
+///      P: ProvideAwsCredentials + Send + Sync + 'static,
+///      D: DispatchSignedRequest + Send + Sync + 'static,
+///  {
+/// ```
+///
+/// While the constructor is generic, the concrete type is not. This is nice, because the user-exposed type isn't generic over the specific credential provider, etc. The
+/// [`QldbDriverBuilder`] has a similar design challenge, but the fluent builder design doesn't leave the option actually accepting generics. So, we use a Box type in our builder, then
+/// implement `ProvideAwsCredentials` for that type. This satisfies the above constraints whilst keeping our API clean.
+pub(crate) fn into_boxed<P>(unboxed: P) -> BoxedCredentialsProvider
+where
+    P: ProvideAwsCredentials + Send + Sync + 'static,
+{
+    BoxedCredentialsProvider {
+        inner: Box::new(unboxed),
+    }
+}
+
+pub(crate) struct BoxedCredentialsProvider {
+    inner: Box<dyn ProvideAwsCredentials + Send + Sync>,
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for BoxedCredentialsProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        self.inner.credentials().await
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,140 @@
+use crate::api::{QldbSessionApi, SessionToken, TransactionId};
+use crate::ion_compat::ion_hash;
+use crate::qldb_hash::QldbHash;
+use crate::QldbError;
+use bytes::Bytes;
+use ion_c_sys::reader::IonCReaderHandle;
+use ion_c_sys::result::IonCError;
+use std::convert::TryFrom;
+use std::error::Error as StdError;
+use tokio::sync::mpsc::Sender;
+
+pub struct StatementResults {
+    values: Vec<Bytes>,
+}
+
+impl StatementResults {
+    fn new(values: Vec<Bytes>) -> StatementResults {
+        StatementResults { values }
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn readers(&self) -> impl Iterator<Item = Result<IonCReaderHandle, IonCError>> {
+        self.values
+            .iter()
+            .map(|bytes| IonCReaderHandle::try_from(&bytes[..]))
+    }
+}
+
+pub enum TransactionDisposition {
+    Commit,
+    Abort,
+}
+
+pub struct TransactionAttempt<R> {
+    pub(crate) tx_id: TransactionId,
+    pub(crate) disposition: TransactionDisposition,
+    pub(crate) user_data: R,
+}
+
+pub struct Transaction {
+    client: Box<dyn QldbSessionApi>,
+    session_token: SessionToken,
+    pub tx_id: TransactionId,
+    commit_digest: QldbHash,
+    channel: Sender<QldbHash>,
+}
+
+impl Transaction {
+    pub(crate) fn new(
+        client: Box<dyn QldbSessionApi>,
+        session_token: SessionToken,
+        tx_id: TransactionId,
+        channel: Sender<QldbHash>,
+    ) -> Transaction {
+        let seed_hash = ion_hash(&tx_id);
+        let commit_digest = QldbHash::from_bytes(seed_hash).unwrap();
+        Transaction {
+            client,
+            session_token,
+            tx_id,
+            commit_digest,
+            channel,
+        }
+    }
+
+    // FIXME: params, result, IonHash
+    pub async fn execute_statement<S>(
+        &mut self,
+        statement: S,
+    ) -> Result<StatementResults, QldbError>
+    where
+        S: Into<String>,
+    {
+        let statement = statement.into();
+
+        let first_page = self
+            .client
+            .execute_statement(&self.session_token, &self.tx_id, statement.clone())
+            .await?;
+
+        let statement_hash = QldbHash::from_bytes(ion_hash(&statement)).unwrap();
+        self.commit_digest = self.commit_digest.dot(&statement_hash);
+
+        let mut values = vec![];
+        let mut current = first_page;
+        loop {
+            let page = match &current {
+                Some(_) => current.take().unwrap(),
+                None => break,
+            };
+
+            if let Some(holders) = page.values {
+                for holder in holders {
+                    let bytes = match (holder.ion_text, holder.ion_binary) {
+                        (None, Some(bytes)) => bytes,
+                        (Some(_txt), None) => unimplemented!(), // TextIonCursor::new(txt),
+                        _ => Err(QldbError::UnexpectedResponse(
+                            "expected only one of ion binary or text".to_string(),
+                        ))?,
+                    };
+                    values.push(bytes);
+                }
+
+                if let Some(next_page_token) = page.next_page_token {
+                    let page = self
+                        .client
+                        .fetch_page(&self.session_token, &self.tx_id, next_page_token)
+                        .await?;
+
+                    if let Some(p) = page {
+                        current.replace(p);
+                    }
+                }
+            }
+        }
+
+        Ok(StatementResults::new(values))
+    }
+
+    pub async fn ok<R>(mut self, user_data: R) -> Result<TransactionAttempt<R>, Box<dyn StdError>> {
+        self.channel.send(self.commit_digest).await?;
+
+        Ok(TransactionAttempt {
+            tx_id: self.tx_id,
+            disposition: TransactionDisposition::Commit,
+            user_data: user_data,
+        })
+    }
+
+    pub async fn abort<R>(self, user_data: R) -> Result<TransactionAttempt<R>, Box<dyn StdError>> {
+        Ok(TransactionAttempt {
+            tx_id: self.tx_id,
+            disposition: TransactionDisposition::Abort,
+            user_data: user_data,
+        })
+    }
+}


### PR DESCRIPTION
This commit implements the `QldbDriver` and supporting acts. Here's
a high-level overview of what we have:

1. QldbDriver can be built with the QldbDriverBuilder
2. The main API is `transact`, which takes in a function
3. The function has one argument: a Transaction, with it's own API
4. Transactions can execute statements or commit/abort

The driver currently only supports an async API, partially because
that's what Rusuto wants to do under the hood anyways. There is a
BlockingQldbDriver that simply blocks on any futures. However, this
driver still exposes the async-Transaction API. As future work, it'd
be great to have a sync-Transaction API to expose
easy-to-use (blocking) C bindings.

The transact API has some subtleties in the type signature that are
worth flagging. First, the param takes a `Fn(Transaction)` as opposed
to `FnOnce` or `FnMut`. This is because we need to be able to retry
transactions (making 'once' not suitable) and want to encourage
idempotent functions (making 'mut' not suitable). Users *can* work
around idempotency with interior mutability, but that is discouraged.

The next subtly worth calling out is that the Fn must return a special
type that is hard to construct manually. Instead, users use an API on
`Transaction` to commit/abort. These methods take the Transaction by
value, making it hard to incorrectly use the transact method (you need
to call one of them, and you can't call them twice).

The commit digest is a bit of a dance due to ownership. Initially I
tried to have the lambda arg be `&mut Transaction` such that executing
statements could mutate a commit digest in the Transaction. That was a
very sad path to go down, given current limitations in the type
system (notably: GAT support). What I settled on is a model where the
transaction accumulates the digest internally and sends it to the
driver on Drop (via a channel). Beacuse the disposition methods take
the tx by value, this has the neat property of immediately making the
digest available to the driver (which has just await'ed the user fn).

The driver interacts with the pooling and retry functionality to
acquire sessions and retry transactions. Hopefully it does it
correctly because there aren't any meaningful tests yet other than the
example included with this commit, the doctest and my own personal
testing. The reason there aren't yet tests is I'm still thinking
through how I want to go about it. (Spoiler: I don't want mocks.)

A couple of other misc. notes:

1. We only support getting values back as Ion binary
2. Pagination is automatic and blocking (there is no async 'read ahead')
3. The User-Agent includes Rust by it is prepended not appended [1]

1: https://github.com/rusoto/rusoto/pull/1838

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
