### PR TITLE
Update from set-env

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Env Variable Setup 
         if: matrix.os == 'windows-latest'
         run: | 
-          echo '::set-env name=LIBCLANG_PATH::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin'
+          echo "LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Git Checkout
         uses: actions/checkout@v2          
       - name: Rust Toolchain


### PR DESCRIPTION
https://github.com/awslabs/amazon-qldb-driver-rust/actions/runs/436569216:

>  The `set-env` command is disabled. Please upgrade to using
> Environment Files or opt into unsecure command execution by setting the
> `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For
> more information see:
> https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
