### PR TITLE
Implement execution stats

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -35,6 +35,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // No support for Ion yet!
     // assert_eq!(42, value);
 
+    info!(
+        "Statement executed in {}ms and used {} read IOs",
+        results
+            .cumulative_timing_information()
+            .as_ref()
+            .unwrap()
+            .processing_time_milliseconds
+            .unwrap(),
+        results
+            .cumulative_io_usage()
+            .as_ref()
+            .unwrap()
+            .read_i_os
+            .unwrap()
+    );
+
     info!("Goodbye!");
 
     Ok(())

--- a/src/api.rs
+++ b/src/api.rs
@@ -46,14 +46,14 @@ pub trait QldbSessionApi {
         session_token: &SessionToken,
         transaction_id: &TransactionId,
         statement: String,
-    ) -> Result<Option<Page>, QldbError>;
+    ) -> Result<ExecuteStatementResult, QldbError>;
 
     async fn fetch_page(
         &self,
         session_token: &SessionToken,
         transaction_id: &TransactionId,
         next_page_token: String,
-    ) -> Result<Option<Page>, QldbError>;
+    ) -> Result<FetchPageResult, QldbError>;
 
     async fn start_session(&self, ledger_name: String) -> Result<SessionToken, QldbError>;
 
@@ -163,7 +163,7 @@ impl QldbSessionApi for QldbSessionClient {
         session_token: &SessionToken,
         transaction_id: &TransactionId,
         statement: String,
-    ) -> Result<Option<Page>, QldbError> {
+    ) -> Result<ExecuteStatementResult, QldbError> {
         let request = SendCommandRequest {
             session_token: Some(session_token.clone()),
             execute_statement: Some(ExecuteStatementRequest {
@@ -181,7 +181,7 @@ impl QldbSessionApi for QldbSessionClient {
             ),
         )?;
 
-        Ok(response.first_page)
+        Ok(response)
     }
 
     // FIXME: dont eat the page
@@ -190,7 +190,7 @@ impl QldbSessionApi for QldbSessionClient {
         session_token: &SessionToken,
         transaction_id: &TransactionId,
         next_page_token: String,
-    ) -> Result<Option<Page>, QldbError> {
+    ) -> Result<FetchPageResult, QldbError> {
         let request = SendCommandRequest {
             session_token: Some(session_token.clone()),
             fetch_page: Some(FetchPageRequest {
@@ -209,7 +209,7 @@ impl QldbSessionApi for QldbSessionClient {
                     "FetchPage requests should return FetchPage responses".into(),
                 ))?;
 
-        Ok(response.page)
+        Ok(response)
     }
 
     async fn start_session(&self, ledger_name: String) -> Result<SessionToken, QldbError> {

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -1,0 +1,98 @@
+///! Maintenance of execution stats.
+///!
+///! The API models TimingInformation as optional, which can make it a little
+///! tricky to accumulate processing time (consider fetching pages of results,
+///! summing total time). The traits here serve to organize this concern out of
+///! the main body of code.
+use rusoto_qldb_session::{IOUsage, TimingInformation};
+
+pub trait TimingInformationExt {
+    fn accumulate(&mut self, other: &Option<TimingInformation>);
+}
+
+impl<T> TimingInformationExt for Option<T>
+where
+    T: TimingInformationExt,
+{
+    fn accumulate(&mut self, other: &Option<TimingInformation>) {
+        if let Some(t) = self {
+            t.accumulate(other);
+        }
+    }
+}
+
+impl TimingInformationExt for TimingInformation {
+    fn accumulate(&mut self, other: &Option<TimingInformation>) {
+        if let Some(o) = other {
+            if let (Some(i), Some(j)) = (
+                self.processing_time_milliseconds,
+                o.processing_time_milliseconds,
+            ) {
+                self.processing_time_milliseconds = Some(i + j)
+            }
+        }
+    }
+}
+
+pub trait IOUsageExt {
+    fn accumulate(&mut self, other: &Option<IOUsage>);
+}
+
+impl<T> IOUsageExt for Option<T>
+where
+    T: IOUsageExt,
+{
+    fn accumulate(&mut self, other: &Option<IOUsage>) {
+        if let Some(t) = self {
+            t.accumulate(other);
+        }
+    }
+}
+
+impl IOUsageExt for IOUsage {
+    fn accumulate(&mut self, other: &Option<IOUsage>) {
+        if let Some(o) = other {
+            if let (Some(i), Some(j)) = (self.read_i_os, o.read_i_os) {
+                self.read_i_os = Some(i + j)
+            }
+
+            if let (Some(i), Some(j)) = (self.write_i_os, o.write_i_os) {
+                self.write_i_os = Some(i + j)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulating_stats() {
+        let mut stats = (
+            TimingInformation {
+                processing_time_milliseconds: Some(1),
+            },
+            IOUsage {
+                read_i_os: Some(1),
+                write_i_os: Some(1),
+            },
+        );
+
+        stats.0.accumulate(&Some(TimingInformation {
+            processing_time_milliseconds: Some(2),
+        }));
+
+        stats.1.accumulate(&Some(IOUsage {
+            read_i_os: Some(2),
+            write_i_os: Some(2),
+        }));
+
+        assert_eq!(
+            TimingInformation {
+                processing_time_milliseconds: Some(3)
+            },
+            stats.0
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate log;
 
 pub mod api;
 pub mod driver;
+pub mod execution_stats;
 pub mod ion_compat;
 pub mod pool;
 pub mod qldb_hash;


### PR DESCRIPTION
This commit implements execution stats for fully buffered results (which
is the only type we currently support).

As we paginate over results, we accumulate total server side processing
time and IO usage. The fully buffered result then presents those to the
user. The 'main' example shows a usage example. Running it on my machine
results in:

```
> RUST_LOG=info cargo run --example main
[2021-01-14T21:46:15Z INFO  main] Creating a QLDB driver
[2021-01-14T21:46:15Z INFO  main] Transaction example 1 now running
[2021-01-14T21:46:16Z INFO  main] Tx 1 returned 1 result(s):
[2021-01-14T21:46:16Z INFO  main] 42
[2021-01-14T21:46:16Z INFO  main] Statement executed in 14ms and used 1 read IOs
[2021-01-14T21:46:16Z INFO  main] Goodbye!
```

There are two things I'm not super excited about in this commit. First,
StatementResults leaks the Rusoto types directly. I think that's a
mistake. Second, it yields `Option` to customers. While this is accurate
given the wire model, the optional values present unneccessary
complexity to users. The Java commit [1] handles this by returning 0s to
customers, which seems right to me.

Regardless, I think this commit adds value and should be merged as is.
Given we're not committing to a stable API yet, this is a pure win.

[1] https://github.com/awslabs/amazon-qldb-driver-java/commit/4cb70843d45330b4884cb21b01e84433ea627359

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
