### PR TITLE
Cleanup transact

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -60,7 +60,7 @@ pub trait QldbSessionApi {
     async fn start_transaction(
         &self,
         session_token: &SessionToken,
-    ) -> Result<TransactionId, QldbError>;
+    ) -> Result<StartTransactionResult, QldbError>;
 }
 
 #[async_trait]
@@ -237,7 +237,7 @@ impl QldbSessionApi for QldbSessionClient {
     async fn start_transaction(
         &self,
         session_token: &SessionToken,
-    ) -> Result<TransactionId, QldbError> {
+    ) -> Result<StartTransactionResult, QldbError> {
         let request = SendCommandRequest {
             session_token: Some(session_token.clone()),
             start_transaction: Some(StartTransactionRequest {}),
@@ -247,14 +247,10 @@ impl QldbSessionApi for QldbSessionClient {
         debug!("request: start_transaction {:?}", request);
         let response = self.send_command(request).await?;
 
-        response
+        Ok(response
             .start_transaction
             .ok_or(QldbError::UnexpectedResponse(
                 "StartTransaction requests should return StartTransaction responses".into(),
-            ))?
-            .transaction_id
-            .ok_or(QldbError::UnexpectedResponse(
-                "StartTransaction should always return a transaction_id".into(),
-            ))
+            ))?)
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,6 +1,6 @@
 use crate::api::QldbSessionApi;
 use crate::rusoto_ext::*;
-use crate::transaction::{Transaction, TransactionAttempt, TransactionDisposition};
+use crate::transaction::{Transaction, TransactionDisposition, TransactionOutcome};
 use crate::{
     pool::SessionPool, retry::default_retry_policy, retry::TransactionRetryPolicy, QldbError,
 };
@@ -198,7 +198,7 @@ impl QldbDriver {
     /// Again, this is because `transaction` is `Fn` not `FnMut` and thus is not allowed to mutate `string`.
     pub async fn transact<F, Fut, R>(&self, transaction: F) -> Result<R, Box<dyn StdError>>
     where
-        Fut: Future<Output = Result<TransactionAttempt<R>, Box<dyn StdError>>>,
+        Fut: Future<Output = Result<TransactionOutcome<R>, Box<dyn StdError>>>,
         F: Fn(Transaction) -> Fut,
     {
         let mut attempt_number = 0u32;
@@ -388,7 +388,7 @@ impl BlockingQldbDriver {
 
     pub fn transact<F, Fut, R>(&self, transaction: F) -> Result<R, Box<dyn StdError>>
     where
-        Fut: Future<Output = Result<TransactionAttempt<R>, Box<dyn StdError>>>,
+        Fut: Future<Output = Result<TransactionOutcome<R>, Box<dyn StdError>>>,
         F: Fn(Transaction) -> Fut,
     {
         let runtime = self.runtime.borrow();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -58,6 +58,7 @@ pub enum TransactionDisposition {
 pub struct TransactionAttempt<R> {
     pub(crate) tx_id: TransactionId,
     pub(crate) disposition: TransactionDisposition,
+    pub(crate) execution_stats: ExecutionStats,
     pub(crate) user_data: R,
 }
 
@@ -153,6 +154,7 @@ impl Transaction {
             }
         }
 
+        self.execution_stats.accumulate(&execution_stats);
         Ok(StatementResults::new(values, execution_stats))
     }
 
@@ -162,6 +164,7 @@ impl Transaction {
         Ok(TransactionAttempt {
             tx_id: self.id,
             disposition: TransactionDisposition::Commit,
+            execution_stats: self.execution_stats,
             user_data: user_data,
         })
     }
@@ -170,6 +173,7 @@ impl Transaction {
         Ok(TransactionAttempt {
             tx_id: self.id,
             disposition: TransactionDisposition::Abort,
+            execution_stats: self.execution_stats,
             user_data: user_data,
         })
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -55,7 +55,7 @@ pub enum TransactionDisposition {
     Abort,
 }
 
-pub struct TransactionAttempt<R> {
+pub struct TransactionOutcome<R> {
     pub(crate) tx_id: TransactionId,
     pub(crate) disposition: TransactionDisposition,
     pub(crate) execution_stats: ExecutionStats,
@@ -158,10 +158,10 @@ impl Transaction {
         Ok(StatementResults::new(values, execution_stats))
     }
 
-    pub async fn ok<R>(self, user_data: R) -> Result<TransactionAttempt<R>, Box<dyn StdError>> {
+    pub async fn ok<R>(self, user_data: R) -> Result<TransactionOutcome<R>, Box<dyn StdError>> {
         self.channel.send(self.commit_digest).await?;
 
-        Ok(TransactionAttempt {
+        Ok(TransactionOutcome {
             tx_id: self.id,
             disposition: TransactionDisposition::Commit,
             execution_stats: self.execution_stats,
@@ -169,8 +169,8 @@ impl Transaction {
         })
     }
 
-    pub async fn abort<R>(self, user_data: R) -> Result<TransactionAttempt<R>, Box<dyn StdError>> {
-        Ok(TransactionAttempt {
+    pub async fn abort<R>(self, user_data: R) -> Result<TransactionOutcome<R>, Box<dyn StdError>> {
+        Ok(TransactionOutcome {
             tx_id: self.id,
             disposition: TransactionDisposition::Abort,
             execution_stats: self.execution_stats,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -62,7 +62,7 @@ pub struct TransactionOutcome<R> {
     pub(crate) user_data: R,
 }
 
-pub struct Transaction {
+pub struct TransactionAttempt {
     client: Box<dyn QldbSessionApi>,
     session_token: SessionToken,
     pub id: TransactionId,
@@ -71,11 +71,11 @@ pub struct Transaction {
     execution_stats: ExecutionStats,
 }
 
-impl Transaction {
+impl TransactionAttempt {
     pub(crate) async fn start(
         client: QldbSessionClient,
         session_token: SessionToken,
-    ) -> Result<(Transaction, Receiver<QldbHash>), QldbError> {
+    ) -> Result<(TransactionAttempt, Receiver<QldbHash>), QldbError> {
         let mut execution_stats = ExecutionStats::default();
         let start_result = client.start_transaction(&session_token).await?;
         execution_stats.accumulate(&start_result);
@@ -88,7 +88,7 @@ impl Transaction {
         let (sender, receiver) = mpsc::channel(1);
         let seed_hash = ion_hash(&id);
         let commit_digest = QldbHash::from_bytes(seed_hash).unwrap();
-        let transaction = Transaction {
+        let transaction = TransactionAttempt {
             client: Box::new(client),
             session_token,
             id,


### PR DESCRIPTION
The individual commits are probably easier to review than the entire change. The TL;DR is I cleaned up the query stats implementation to address the problems I previously called out, as well as started to fix some of the abstractions between Driver and Transaction.