### PR TITLE
Make the driver cloneable to enable concurrent use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,9 @@ name = "amazon-qldb-driver"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "async-trait",
+ "bb8",
  "bytes 1.0.1",
  "env_logger 0.8.2",
  "futures",
@@ -46,6 +48,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arc-swap"
@@ -92,6 +100,19 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bb8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae93eccab998c4b8703e3a6bbaa1714c38e445ebacb4bede25d0408521e293c"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -616,6 +637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "ion-c-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +691,15 @@ checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
  "winapi",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -827,6 +866,31 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.4",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1180,6 +1244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1358,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -1504,6 +1580,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite 0.2.4",
  "signal-hook-registry",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.23"
+thiserror = "1.0"
+anyhow = "1.0"
 tokio = "1.0.1"
 bytes = "1.0.1"
 async-trait = "0.1.42"
@@ -18,6 +19,7 @@ log = "0.4.13"
 ion-c-sys = "0.4.3"
 rand = "0.8.2"
 futures = "0.3.11"
+bb8 = "0.7.0"
 
 [dev-dependencies]
 hex-literal = "0.3.1"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,5 +1,5 @@
 use amazon_qldb_driver::ion_compat;
-use amazon_qldb_driver::QldbDriver;
+use amazon_qldb_driver::QldbDriverBuilder;
 use rusoto_core::Region;
 use tokio;
 #[macro_use]
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     info!("Creating a QLDB driver");
-    let driver = QldbDriver::builder()
+    let driver = QldbDriverBuilder::new()
         .ledger_name("sample-ledger")
         .region(Region::UsWest2)
         .build()?;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,118 +1,79 @@
+use std::fmt::Debug;
+
 use crate::api::{QldbSessionApi, SessionToken};
 use crate::QldbError;
-use futures::future::FutureExt;
+use async_trait::async_trait;
+use bb8::{ErrorSink, ManageConnection};
 use rusoto_qldb_session::*;
-use std::{
-    cell::RefCell,
-    sync::atomic::{AtomicUsize, Ordering},
-};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
-type Message = (SessionToken, bool);
+pub struct QldbSessionManager<C>
+where
+    C: QldbSession + Send + Sync,
+{
+    pub client: C,
+    pub ledger_name: String,
+}
 
-/// A pool of sessions. The pool will hold up to a configured [`max`] number of sessions, after which requests will begin to queue. To get a session, call [`next`]. This returns a RAII
-/// guard that will release the session back into the pool when it goes out of scope.
+#[derive(Debug, Copy, Clone)]
+pub struct QldbErrorLoggingErrorSink;
+
+impl QldbErrorLoggingErrorSink {
+    pub fn new() -> QldbErrorLoggingErrorSink {
+        QldbErrorLoggingErrorSink {}
+    }
+}
+
+impl ErrorSink<QldbError> for QldbErrorLoggingErrorSink {
+    fn sink(&self, error: QldbError) {
+        debug!("error in connection pool: {}", error);
+    }
+
+    fn boxed_clone(&self) -> Box<dyn ErrorSink<QldbError>> {
+        Box::new(*self)
+    }
+}
+
+/// A HTTP/1 based connection to QLDB. There is no one physical connection.
+/// Rather, a connection is represented by a "session token" (a unique, opaque
+/// string) that is passed as a parameter over an HTTP/1 request.
 ///
-/// Invalid sessions should be marked as such via [`notify_invalid`], and the caller should decide if another session should be acquired.
-///
-/// Note this pool uses interior mutability such that [`next`] does not require a mutable reference. In turn this allows higher level layers (such as the driver's `transact` method) to not
-/// require a mutable ref.
-pub(crate) struct SessionPool {
-    client: QldbSessionClient,
-    ledger_name: String,
-    max: usize,
-    current: AtomicUsize,
-    ch: (Sender<Message>, RefCell<Receiver<Message>>),
+/// [`discard`] should be set to true if an API response ever indicates the
+/// session is broken.
+pub struct QldbHttp1Connection {
+    pub token: SessionToken,
+    discard: bool,
 }
 
-// FIXME: Make thread-safe then implement Sync (replace RefCell with Mutex or RwLock?).
-impl SessionPool {
-    pub(crate) fn new(client: QldbSessionClient, ledger_name: String, max: usize) -> SessionPool {
-        let (sender, receiver) = channel(max);
-        let receiver = RefCell::new(receiver);
-
-        SessionPool {
-            client: client,
-            ledger_name: ledger_name,
-            max: max,
-            current: AtomicUsize::new(0),
-            ch: (sender, receiver),
-        }
-    }
-
-    /// Return a [`SessionHandle`] either from the pool or by creating a new session. If the maximum number of sessions have been opened, this method will introduce latency backpressure. It
-    /// will propogate API errors (e.g. unable to start a new session due to limits, API throttling) to the caller.
-    pub(crate) async fn next(&self) -> Result<SessionHandle, QldbError> {
-        // Keep processing the queue of returned sessions until we find one that isn't marked invalid.
-        loop {
-            // Note that for the 'pool is full' case, we should *always* get `Some` out of this block (we use `recv`, which waits for one), while in the 'not full' case we don't wait.
-            let next = if self.current.load(Ordering::SeqCst) == self.max {
-                match self.ch.1.borrow_mut().recv().await {
-                    Some(m) => m,
-                    None => unreachable!(
-                        "bug! pool is at max capacity but there are no outstanding session handles"
-                    ),
-                }
-            } else {
-                match self.ch.1.borrow_mut().recv().now_or_never() {
-                    Some(Some(m)) => m,
-                    None => break, // there are no more sessions in the pool
-                    Some(None) => {
-                        unreachable!("bug! pool recv channel should not be closed")
-                    }
-                }
-            };
-
-            // We found a free session. If it's valid, return it. Otherwise, increase our permits.
-            match next {
-                (token, true) => return Ok(self.build_handle(token)),
-                (_, false) => self.current.fetch_sub(1, Ordering::SeqCst),
-            };
-        }
-
-        // It should be impossible at this point to be at max sessions due to the guard right at the start of this method (if we're at max, we add delay).
-        if self.current.load(Ordering::SeqCst) == self.max {
-            unreachable!("bug! pool is at max sessions but wants to make a new one");
-        }
-
-        // This code runs when either there was no available session or the one that came back was invalid.
-        self.current.fetch_add(1, Ordering::SeqCst);
-        let session_token = self.client.start_session(self.ledger_name.clone()).await?;
-        return Ok(self.build_handle(session_token));
-    }
-
-    fn build_handle(&self, session_token: SessionToken) -> SessionHandle {
-        SessionHandle {
-            session_token: session_token,
-            invalid: false,
-            notify: self.ch.0.clone(),
-        }
+impl QldbHttp1Connection {
+    pub fn notify_invalid(&mut self) {
+        self.discard = true;
     }
 }
 
-pub(crate) struct SessionHandle {
-    pub(crate) session_token: SessionToken,
-    invalid: bool,
-    notify: Sender<Message>,
-}
+#[async_trait]
+impl<C> ManageConnection for QldbSessionManager<C>
+where
+    C: QldbSession + Send + Sync + 'static,
+{
+    type Connection = QldbHttp1Connection;
+    type Error = QldbError;
 
-impl SessionHandle {
-    pub(crate) fn notify_invalid(mut self) {
-        self.invalid = true;
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let token = self.client.start_session(self.ledger_name.clone()).await?;
+        Ok(QldbHttp1Connection {
+            token,
+            discard: false,
+        })
     }
-}
 
-impl Drop for SessionHandle {
-    fn drop(&mut self) {
-        // Should never fail because the channel is bounded by the same valid as the max pool size.
-        if let Err(e) = self
-            .notify
-            .try_send((self.session_token.clone(), self.invalid))
-        {
-            debug!(
-                "Unable to return session {} to the session pool: {}",
-                self.session_token, e
-            );
-        }
+    async fn is_valid(
+        &self,
+        _conn: &mut bb8::PooledConnection<'_, Self>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn has_broken(&self, conn: &mut Self::Connection) -> bool {
+        conn.discard
     }
 }

--- a/src/rusoto_ext.rs
+++ b/src/rusoto_ext.rs
@@ -15,9 +15,15 @@ use rusoto_core::credential::{AwsCredentials, CredentialsError, ProvideAwsCreden
 ///  {
 /// ```
 ///
-/// While the constructor is generic, the concrete type is not. This is nice, because the user-exposed type isn't generic over the specific credential provider, etc. The
-/// [`QldbDriverBuilder`] has a similar design challenge, but the fluent builder design doesn't leave the option actually accepting generics. So, we use a Box type in our builder, then
-/// implement `ProvideAwsCredentials` for that type. This satisfies the above constraints whilst keeping our API clean.
+/// While the constructor is generic, the concrete type is not. This is nice,
+/// because the user-exposed type isn't generic over the specific credential
+/// provider, etc.
+///
+/// The [`QldbDriverBuilder`] has a similar design challenge, but the fluent
+/// builder design doesn't leave the option actually accepting generics. So, we
+/// use a Box type in our builder, then implement `ProvideAwsCredentials` for
+/// that type. This satisfies the above constraints whilst keeping our API
+/// clean.
 pub(crate) fn into_boxed<P>(unboxed: P) -> BoxedCredentialsProvider
 where
     P: ProvideAwsCredentials + Send + Sync + 'static,


### PR DESCRIPTION
This is a fairly large commit. Before, the driver was none of Send, Sync
or Clone. There was no way to use it in a concurrent application. Your
only choice was a single-threaded Tokio runtime.

There are really three things going on with the driver. First, we have
the client (a Rusoto client) that manages HTTPS connections and
credentials. Next, we have the pool of sessions. And, finally, the
transactional code that customers write.

Before this commit, you *could* make multiple drivers and use the same
Rusoto client (since cloning it is just an Arc clone), but you'd not use
the same SessionPool. In this commit, we make SessionPool cloneable by
reimplementing it on top of bb8.

That leaves us with the challenge of multiple threads using the same
driver. In essence, the top-level requirement that tokio has on the
Future being Send created a lot of trouble. I added Arcs and wove
through trait requirements until everything eventually worked.

There was a particular question around TransactionRetryPolicy - if there
is only 1 driver with shallow clones, then what are the Send/Sync
requirements on the policy? Ultimately, I decided to keep the
implementation requirements of the policy simple and wrap it in a Mutex.
That bubbled up yet more Send requirements, leading me to change the
trait itself. Now it's not async_trait and the sleep is done by the
caller not the code itself. I think this is better anyways, the previous
"policy can sleep" strategy was going to make the Mutex tricky to use.

I added some testing, which resulted in weaving a `C: QldbSession`
throughout the codebase, as well as some changes to the builder. There
is a hand-written testing client that isn't very good. A new test shows
how you can use the driver from more than one thread. The test doesn't
pass 100% of the time; which is a good thing at some level! Bear with
me. The mock returns results in order, while the tests run in OS
scheduling order. So, tx-1 might get the mock results for tx-0. The
invariant checking the driver does causes the failure. As future work,
we should make the mock smarter so that we can control more specifically
what the return order is.

Also: move from std::result to anyhow::Result (removes box StdError
type) and start trying to rationalize how the driver will support real
threads concurrency.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
