### PR TITLE
Rename ok to commit

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -160,14 +160,19 @@ where
         Ok(StatementResults::new(values, execution_stats))
     }
 
+    #[deprecated(note = "Please use commit instead")]
     pub async fn ok<R>(self, user_data: R) -> Result<TransactionOutcome<R>> {
+        self.commit(user_data)
+    }
+
+    pub async fn commit<R>(self, user_data: R) -> Result<TransactionOutcome<R>> {
         self.channel.send(self.commit_digest).await?;
 
         Ok(TransactionOutcome {
             tx_id: self.id,
             disposition: TransactionDisposition::Commit,
             execution_stats: self.execution_stats,
-            user_data: user_data,
+            user_data,
         })
     }
 
@@ -176,7 +181,7 @@ where
             tx_id: self.id,
             disposition: TransactionDisposition::Abort,
             execution_stats: self.execution_stats,
-            user_data: user_data,
+            user_data,
         })
     }
 }


### PR DESCRIPTION
Initially it seemed like a good idea to call the method 'ok' in the
style of Ok/Err Result types. However, when explaining usage to users, I
landed up having to explain that "ok calls commit".

This commit deprecates `ok` so that we can stage the change in one
commit here, then upgrade the shell in a second commit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
