### PR TITLE
Further refactor the `abort` API

### DIFF
--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -117,6 +117,19 @@ pub trait HasExecutionStats {
     fn io_usage(&self) -> Option<IOUsage>;
 }
 
+impl ExecutionStats {
+    // Can't use From here because it conflicts with the stdlib.
+    pub(crate) fn from_api<S>(s: S) -> ExecutionStats
+    where
+        S: HasExecutionStats,
+    {
+        ExecutionStats {
+            timing_information: s.timing_information(),
+            io_usage: s.io_usage().unwrap_or(IOUsage::default()),
+        }
+    }
+}
+
 impl HasExecutionStats for ExecutionStats {
     fn timing_information(&self) -> TimingInformation {
         self.timing_information.clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod retry;
 pub mod rusoto_ext;
 pub mod transaction;
 
-pub use crate::driver::{BlockingQldbDriver, QldbDriver, QldbDriverBuilder};
+pub use crate::driver::{QldbDriver, QldbDriverBuilder};
 
 #[derive(Error, Debug)]
 pub enum QldbError {


### PR DESCRIPTION
As per the comments, the abort API allowed returning data (bad) and
showed up as an `Ok` variant to the caller (bad). Now, calling abort
does *not* let the caller export data and, instead, the abort will cause
the `transact` call to return an `Err`.

This (aborted error) is an `anyhow::Result`, so if application code
wants to specifically handle it, they must use the downcast method as
shown in a test.

I think this change makes it easier to write correct code and also
removes the need to put fake `R` data in the call to abort.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
