### PR TITLE
Update aws-sdk-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "async-trait",
  "aws-sdk-qldbsession",
  "bb8",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures",
  "hex-literal",
  "http",
@@ -45,7 +45,7 @@ dependencies = [
  "ion-rs",
  "rand",
  "sha2",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "thiserror",
  "tokio",
  "tracing",
@@ -58,13 +58,13 @@ version = "0.1.0"
 dependencies = [
  "amazon-qldb-driver-core",
  "async-trait",
- "aws-auth 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha)",
+ "aws-auth",
  "aws-sdk-qldbsession",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http",
  "rusoto_core",
  "rusoto_qldb_session",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "tokio",
 ]
 
@@ -99,17 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "assert-json-diff"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
-dependencies = [
- "extend",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,19 +129,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aws-auth"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
- "zeroize",
-]
-
-[[package]]
-name = "aws-auth"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha#7c5f3753b8fce99b43f7c1a4fe5f2dd8077b95e3"
-dependencies = [
- "aws-types 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha)",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha)",
+ "aws-types",
+ "pin-project",
+ "smithy-async",
+ "smithy-http",
  "tokio",
  "tracing",
  "zeroize",
@@ -161,48 +143,47 @@ dependencies = [
 [[package]]
 name = "aws-endpoint"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "aws-types 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-types",
  "http",
  "regex",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
 ]
 
 [[package]]
 name = "aws-http"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "aws-types 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-types",
  "http",
  "lazy_static",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
+ "smithy-types",
  "thiserror",
 ]
 
 [[package]]
 name = "aws-hyper"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "aws-auth 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-auth",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fastrand",
  "http",
  "http-body",
  "hyper",
  "hyper-rustls",
  "pin-project",
- "protocol-test-helpers",
  "smithy-client",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "smithy-http-tower",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-types",
  "tokio",
  "tower",
  "tracing",
@@ -210,68 +191,57 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-qldbsession"
-version = "0.0.12-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+version = "0.0.16-alpha"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "aws-auth 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-auth",
  "aws-endpoint",
  "aws-http",
  "aws-hyper",
  "aws-sig-auth",
- "aws-types 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
- "bytes 1.0.1",
+ "aws-types",
+ "bytes 1.1.0",
  "http",
- "serde_json",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "smithy-json",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-types",
 ]
 
 [[package]]
 name = "aws-sig-auth"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "aws-auth 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-auth",
  "aws-sigv4",
- "aws-types 0.1.0 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "aws-types",
  "http",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "thiserror",
 ]
 
 [[package]]
 name = "aws-sigv4"
 version = "0.1.0"
-source = "git+https://github.com/rcoh/sigv4?rev=66b1646a7ab119c73be966ca70ee5f556bd8379b#66b1646a7ab119c73be966ca70ee5f556bd8379b"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "bytes 1.0.1",
  "chrono",
+ "form_urlencoded",
  "hex",
  "http",
  "http-body",
  "percent-encoding",
  "ring",
- "serde",
- "serde_urlencoded",
+ "smithy-eventstream",
 ]
 
 [[package]]
 name = "aws-types"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
  "lazy_static",
- "rustc_version 0.3.3",
-]
-
-[[package]]
-name = "aws-types"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha#7c5f3753b8fce99b43f7c1a4fe5f2dd8077b95e3"
-dependencies = [
- "lazy_static",
- "rustc_version 0.4.0",
+ "rustc_version",
  "tracing",
 ]
 
@@ -385,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytes-utils"
@@ -395,7 +365,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "either",
 ]
 
@@ -523,16 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "delegate"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +502,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -596,18 +550,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "extend"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -768,7 +710,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -824,7 +766,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -835,7 +777,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http",
  "pin-project-lite",
 ]
@@ -864,7 +806,7 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1190,15 +1132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,15 +1175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,42 +1213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "pretty_assertions"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
-dependencies = [
- "ansi_term 0.12.1",
- "ctor",
- "diff",
- "output_vt100",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,20 +1231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "protocol-test-helpers"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
-dependencies = [
- "assert-json-diff",
- "http",
- "pretty_assertions",
- "regex",
- "roxmltree",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1475,15 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
 name = "rusoto_core"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,7 +1356,7 @@ checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "crc32fast",
  "futures",
  "http",
@@ -1501,7 +1366,7 @@ dependencies = [
  "log",
  "rusoto_credential",
  "rusoto_signature",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "serde_json",
  "tokio",
@@ -1533,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "407424e9851c8f68697e3408f9e5b4a0ecbe5173b9568d01f19b463383840071"
 dependencies = [
  "async-trait",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures",
  "rusoto_core",
  "serde",
@@ -1547,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "chrono",
  "digest",
  "futures",
@@ -1560,7 +1425,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rusoto_credential",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "sha2",
  "tokio",
@@ -1574,20 +1439,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.3",
+ "semver",
 ]
 
 [[package]]
@@ -1672,27 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -1720,18 +1558,6 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
-dependencies = [
- "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1787,52 +1613,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
+name = "smithy-async"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "smithy-client"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fastrand",
  "http",
  "http-body",
  "hyper",
  "hyper-rustls",
  "pin-project",
- "protocol-test-helpers",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "smithy-http-tower",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-types",
  "tokio",
  "tower",
  "tracing",
 ]
 
 [[package]]
-name = "smithy-http"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+name = "smithy-eventstream"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "bytes 1.0.1",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "percent-encoding",
- "pin-project",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
+ "bytes 1.1.0",
+ "crc32fast",
+ "smithy-types",
 ]
 
 [[package]]
 name = "smithy-http"
 version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha#7c5f3753b8fce99b43f7c1a4fe5f2dd8077b95e3"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "bytes-utils",
  "futures-core",
  "http",
@@ -1840,7 +1664,8 @@ dependencies = [
  "hyper",
  "percent-encoding",
  "pin-project",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha)",
+ "smithy-eventstream",
+ "smithy-types",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1850,13 +1675,13 @@ dependencies = [
 [[package]]
 name = "smithy-http-tower"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http",
  "http-body",
  "pin-project",
- "smithy-http 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
+ "smithy-http",
  "tower",
  "tracing",
 ]
@@ -1864,27 +1689,20 @@ dependencies = [
 [[package]]
 name = "smithy-json"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
 dependencies = [
+ "smithy-types",
+]
+
+[[package]]
+name = "smithy-types"
+version = "0.0.1"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.16-alpha#dab3b0a97d8213105549f35914670dd7bd91d619"
+dependencies = [
+ "chrono",
  "itoa",
+ "num-integer",
  "ryu",
- "smithy-types 0.0.1 (git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha)",
-]
-
-[[package]]
-name = "smithy-types"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.12-alpha#d61aa9575151b9e9ac88810e65d5481860d8a552"
-dependencies = [
- "chrono",
-]
-
-[[package]]
-name = "smithy-types"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.13-alpha#7c5f3753b8fce99b43f7c1a4fe5f2dd8077b95e3"
-dependencies = [
- "chrono",
 ]
 
 [[package]]
@@ -1997,12 +1815,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "libc",
  "memchr",
  "mio",
@@ -2043,7 +1861,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log",
@@ -2134,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2165,12 +1983,6 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-width"
@@ -2343,12 +2155,6 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "zeroize"

--- a/amazon-qldb-driver-core/Cargo.toml
+++ b/amazon-qldb-driver-core/Cargo.toml
@@ -7,26 +7,26 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.25"
+thiserror = "1.0.26"
 anyhow = "1.0.43"
-tokio = { version = "1", features = ["full"] }
-bytes = "1.0.1"
+tokio = { version = "1.10.1", features = ["full"] }
+bytes = "1.1.0"
 async-trait = "0.1.51"
 # Note: The default features include "client" which generates an actual client.
 # We don't want that! Instead, we just want the *shapes*. This allows the -core
 # package to be agnostic of the actual client used.
-aws_sdk_qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.12-alpha", package = "aws-sdk-qldbsession", features = ["rustls"] }
-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.12-alpha", package = "smithy-http", features = [] }
+aws_sdk_qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.16-alpha", package = "aws-sdk-qldbsession", features = ["rustls"] }
+smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.16-alpha", package = "smithy-http", features = [] }
 sha2 = "0.9.5"
-ion-rs = "0.6"
-ion-c-sys = "0.4.9"
-rand = "0.8.3"
+ion-rs = "0.6.0"
+ion-c-sys = "0.4.11"
+rand = "0.8.4"
 futures = "0.3.16"
 bb8 = "0.7.1"
-tracing = "0.1.25"
+tracing = "0.1.26"
 http = "0.2.4"
 
 [dev-dependencies]
 hex-literal = "0.3.3"
 ansi_term = "0.12.1"
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.2.20", features = ["fmt"] }

--- a/amazon-qldb-driver-core/src/retry.rs
+++ b/amazon-qldb-driver-core/src/retry.rs
@@ -104,7 +104,7 @@ impl TransactionRetryPolicy for ExponentialBackoffJitterTransactionRetryPolicy {
                     // have been sent. In QLDB, the commit digest protects
                     // against a duplicate statement being sent.
                     SdkError::DispatchFailure(_) => true,
-                    SdkError::ResponseError { raw, .. } => match raw.status().as_u16() {
+                    SdkError::ResponseError { raw, .. } => match raw.http().status().as_u16() {
                         500 | 503 => true,
                         _ => false,
                     },

--- a/amazon-qldb-driver-rusoto/Cargo.toml
+++ b/amazon-qldb-driver-rusoto/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 
 [dependencies]
 amazon-qldb-driver-core = { version = "*", path = "../amazon-qldb-driver-core" }
-aws_sdk_qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.12-alpha", package = "aws-sdk-qldbsession", features = ["rustls"] }
-smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.12-alpha", package = "smithy-http", features = [] }
-aws-auth = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.13-alpha", package = "aws-auth", features = [] }
-rusoto_core = { version = "0.47.0", default_features = false, features = ["rustls"]}
-rusoto_qldb_session = { version = "0.47.0", default_features = false, features = ["rustls"]}
+aws_sdk_qldbsession = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.16-alpha", package = "aws-sdk-qldbsession", features = ["rustls"] }
+smithy-http = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.16-alpha", package = "smithy-http", features = [] }
+aws-auth = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.16-alpha", package = "aws-auth", features = [] }
+rusoto_core = { version = "0.47.0", default_features = false, features = ["rustls"] }
+rusoto_qldb_session = { version = "0.47.0", default_features = false, features = ["rustls"] }
 async-trait = "0.1.51"
-bytes = "1.0.1"
+bytes = "1.1.0"
 http = "0.2.4"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.10.1", features = ["full"] }

--- a/amazon-qldb-driver-rusoto/src/convert.rs
+++ b/amazon-qldb-driver-rusoto/src/convert.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 use rusoto_core::RusotoError;
 use rusoto_qldb_session::{self, QldbSessionClient};
 use smithy_http::body::SdkBody;
+use smithy_http::operation;
 
 use amazon_qldb_driver_core::error::{StringError, UnitError};
 
@@ -363,7 +364,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
                 rusoto_qldb_session::SendCommandError::InvalidSession(message) => {
@@ -374,7 +377,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
                 rusoto_qldb_session::SendCommandError::LimitExceeded(message) => {
@@ -385,7 +390,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
                 rusoto_qldb_session::SendCommandError::OccConflict(message) => {
@@ -396,7 +403,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
                 rusoto_qldb_session::SendCommandError::RateExceeded(message) => {
@@ -407,7 +416,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
                 rusoto_qldb_session::SendCommandError::CapacityExceeded(message) => {
@@ -420,7 +431,9 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                             ),
                             Default::default(),
                         ),
-                        raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        raw: operation::Response::new(
+                            http::Response::builder().body(SdkBody::empty()).unwrap(),
+                        ),
                     }
                 }
             },
@@ -430,11 +443,15 @@ impl ConvertFrom<RusotoError<rusoto_qldb_session::SendCommandError>>
                 SdkError::ConstructionFailure(Box::new(StringError(message)))
             }
             RusotoError::ParseError(message) => SdkError::ResponseError {
-                raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                raw: operation::Response::new(
+                    http::Response::builder().body(SdkBody::empty()).unwrap(),
+                ),
                 err: Box::new(StringError(message)),
             },
             RusotoError::Unknown(_http) => SdkError::ResponseError {
-                raw: http::Response::builder().body(SdkBody::empty()).unwrap(),
+                raw: operation::Response::new(
+                    http::Response::builder().body(SdkBody::empty()).unwrap(),
+                ),
                 err: Box::new(UnitError),
             },
             RusotoError::Blocking => {

--- a/amazon-qldb-driver/Cargo.toml
+++ b/amazon-qldb-driver/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2018"
 [dependencies]
 amazon-qldb-driver-core = { version = "*", path = "../amazon-qldb-driver-core" }
 amazon-qldb-driver-rusoto = { version = "*", path = "../amazon-qldb-driver-rusoto" }
-tokio = "1.10.0"
-rusoto_core = { version = "0.47.0", default_features = false, features = ["rustls"]}
-rusoto_qldb_session = { version = "0.47.0", default_features = false, features = ["rustls"]}
+tokio = "1.10.1"
+rusoto_core = { version = "0.47.0", default_features = false, features = ["rustls"] }
+rusoto_qldb_session = { version = "0.47.0", default_features = false, features = ["rustls"] }
 
 [dev-dependencies]
-thiserror = "1.0.25"
+thiserror = "1.0.26"
 anyhow = "1.0.43"
-tracing = "0.1.25"
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
-ion-rs = "0.6"
-ion-c-sys = "0.4.9"
+tracing = "0.1.26"
+tracing-subscriber = { version = "0.2.20", features = ["fmt"] }
+ion-rs = "0.6.0"
+ion-c-sys = "0.4.11"


### PR DESCRIPTION
This commit upgrades the aws-sdk-rust and keeps up with breaking changes
as per the release notes.

I also ran `cargo upgrade --workspace` to pickup crate updates. The
tests pass, and the examples run.