### PR TITLE
Fix full jitter algorithm

### DIFF
--- a/amazon-qldb-driver-core/src/retry.rs
+++ b/amazon-qldb-driver-core/src/retry.rs
@@ -125,7 +125,7 @@ impl TransactionRetryPolicy for ExponentialBackoffJitterTransactionRetryPolicy {
 
 fn exponential_backoff_with_jitter(base: u32, cap: u32, attempt_number: u32) -> u32 {
     let max = min(cap, base * 2_u32.pow(attempt_number));
-    thread_rng().gen_range(1..max)
+    thread_rng().gen_range(0..max)
 }
 
 #[cfg(test)]
@@ -140,7 +140,7 @@ mod tests {
             max_attempts,
         } = ExponentialBackoffJitterTransactionRetryPolicy::default();
 
-        let mut seq = vec![1..20, 1..40, 1..80, 1..160];
+        let mut seq = vec![0..20, 0..40, 0..80, 0..160];
         seq.reverse();
 
         for attempt_number in 1..=max_attempts {

--- a/amazon-qldb-driver-core/src/retry.rs
+++ b/amazon-qldb-driver-core/src/retry.rs
@@ -124,8 +124,8 @@ impl TransactionRetryPolicy for ExponentialBackoffJitterTransactionRetryPolicy {
 }
 
 fn exponential_backoff_with_jitter(base: u32, cap: u32, attempt_number: u32) -> u32 {
-    let max = min(cap, base.pow(attempt_number));
-    thread_rng().gen_range(0..max)
+    let max = min(cap, base * 2_u32.pow(attempt_number));
+    thread_rng().gen_range(1..max)
 }
 
 #[cfg(test)]
@@ -140,7 +140,7 @@ mod tests {
             max_attempts,
         } = ExponentialBackoffJitterTransactionRetryPolicy::default();
 
-        let mut seq = vec![0..10, 0..100, 0..1000, 0..5000]; // not super tight
+        let mut seq = vec![1..20, 1..40, 1..80, 1..160];
         seq.reverse();
 
         for attempt_number in 1..=max_attempts {


### PR DESCRIPTION
The correct full jitter max time using the base sleep: base * 2 ** attempt_number

Issue #, if available: 
n/a

Description of changes:
Full jitter algorithm is incorrectly using the base sleep milliseconds ** attempt_number. Using 2 to the power of attempt creates much smaller increments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
